### PR TITLE
Add configuration flag to set if recuresion desired should be set on …

### DIFF
--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -28,9 +28,10 @@ var log = clog.NewWithPlugin("forward")
 type Forward struct {
 	concurrent int64 // atomic counters need to be first in struct for proper alignment
 
-	proxies    []*Proxy
-	p          policy.Policy
-	hcInterval time.Duration
+	proxies            []*Proxy
+	p                  policy.Policy
+	hcInterval         time.Duration
+	hcRecursionDesired bool
 
 	from    string
 	ignored []string
@@ -52,7 +53,7 @@ type Forward struct {
 
 // New returns a new Forward.
 func New() *Forward {
-	f := &Forward{maxfails: 2, tlsConfig: new(tls.Config), expire: defaultExpire, p: new(policy.Random), from: ".", hcInterval: hcInterval}
+	f := &Forward{maxfails: 2, tlsConfig: new(tls.Config), expire: defaultExpire, p: new(policy.Random), from: ".", hcInterval: hcInterval, hcRecursionDesired: true}
 	return f
 }
 

--- a/plugin/forward/health.go
+++ b/plugin/forward/health.go
@@ -14,10 +14,14 @@ import (
 type HealthChecker interface {
 	Check(*Proxy) error
 	SetTLSConfig(*tls.Config)
+	SetRecursionDesired(bool)
 }
 
 // dnsHc is a health checker for a DNS endpoint (DNS, and DoT).
-type dnsHc struct{ c *dns.Client }
+type dnsHc struct {
+	c                *dns.Client
+	recursionDesired bool
+}
 
 // NewHealthChecker returns a new HealthChecker based on transport.
 func NewHealthChecker(trans string) HealthChecker {
@@ -28,7 +32,7 @@ func NewHealthChecker(trans string) HealthChecker {
 		c.ReadTimeout = 1 * time.Second
 		c.WriteTimeout = 1 * time.Second
 
-		return &dnsHc{c: c}
+		return &dnsHc{c: c, recursionDesired: true}
 	}
 
 	log.Warningf("No healthchecker for transport %q", trans)
@@ -40,7 +44,11 @@ func (h *dnsHc) SetTLSConfig(cfg *tls.Config) {
 	h.c.TLSConfig = cfg
 }
 
-// For HC we send to . IN NS +norec message to the upstream. Dial timeouts and empty
+func (h *dnsHc) SetRecursionDesired(recursionDesired bool) {
+	h.recursionDesired = recursionDesired
+}
+
+// For HC we send to . IN NS +[no]rec message to the upstream. Dial timeouts and empty
 // replies are considered fails, basically anything else constitutes a healthy upstream.
 
 // Check is used as the up.Func in the up.Probe.
@@ -59,7 +67,7 @@ func (h *dnsHc) Check(p *Proxy) error {
 func (h *dnsHc) send(addr string) error {
 	ping := new(dns.Msg)
 	ping.SetQuestion(".", dns.TypeNS)
-	ping.MsgHdr.RecursionDesired = false
+	ping.MsgHdr.RecursionDesired = h.recursionDesired
 
 	m, _, err := h.c.Exchange(ping, addr)
 	// If we got a header, we're alright, basically only care about I/O errors 'n stuff.

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -43,6 +43,11 @@ func (p *Proxy) SetTLSConfig(cfg *tls.Config) {
 // SetExpire sets the expire duration in the lower p.transport.
 func (p *Proxy) SetExpire(expire time.Duration) { p.transport.SetExpire(expire) }
 
+// SetRecursionDesired sets recuresion desired flag on the lower proxy health checker
+func (p *Proxy) SetRecursionDesired(recursionDesired bool) {
+	p.health.SetRecursionDesired(recursionDesired)
+}
+
 // Healthcheck kicks of a round of health checks for this proxy.
 func (p *Proxy) Healthcheck() {
 	if p.health == nil {

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -121,6 +121,7 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 			f.proxies[i].SetTLSConfig(f.tlsConfig)
 		}
 		f.proxies[i].SetExpire(f.expire)
+		f.proxies[i].SetRecursionDesired(f.hcRecursionDesired)
 	}
 
 	return f, nil
@@ -161,6 +162,11 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 			return fmt.Errorf("health_check can't be negative: %d", dur)
 		}
 		f.hcInterval = dur
+	case "health_check_prefer_no_recursion":
+		if c.NextArg() {
+			return c.ArgErr()
+		}
+		f.hcRecursionDesired = false
 	case "force_tcp":
 		if c.NextArg() {
 			return c.ArgErr()

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -31,11 +31,13 @@ func TestSetup(t *testing.T) {
 		{"forward . 127.0.0.1:8080", false, ".", nil, 2, options{}, ""},
 		{"forward . [::1]:53", false, ".", nil, 2, options{}, ""},
 		{"forward . [2003::1]:53", false, ".", nil, 2, options{}, ""},
+		{"forward . 127.0.0.1 {\nhealth_check_prefer_no_recursion\n}\n", false, ".", nil, 2, options{}, ""},
 		// negative
 		{"forward . a27.0.0.1", true, "", nil, 0, options{}, "not an IP"},
 		{"forward . 127.0.0.1 {\nblaatl\n}\n", true, "", nil, 0, options{}, "unknown property"},
 		{`forward . ::1
 		forward com ::2`, true, "", nil, 0, options{}, "plugin"},
+		{"forward . 127.0.0.1 {\nhealth_check_prefer_no_recursion true\n}\n", true, ".", nil, 2, options{}, "Wrong argument count or unexpected line ending"},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
…each proxy's health checker

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

We would like to configure the health checker for the proxies whether they should do recursive queries (default) or turn it off by setting `health_check_prefer_no_recursion` in the configuration.

### 2. Which issues (if any) are related?

Issues in our environment involve upstream queries to time out before the anwer gets back because of how the dns servers (upstream) are configured. They are out of our control and we only care if they are alive.

### 3. Which documentation changes (if any) need to be made?

Configuration file for the forward plugin should reflect the new optional flag to turn off recursion on the health checker.

### 4. Does this introduce a backward incompatible change or deprecation?

No. The default is to keep recursion requests on by default as is coded in previous versions of forward plugin.
